### PR TITLE
Deploying blueprint xml from template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,22 +10,45 @@ alpaca_karaf_repos:
 
 alpaca_features:
   - islandora-http-client
-  - islandora-connector-broadcast
   - islandora-indexing-triplestore
   - islandora-indexing-fcrepo
-  - islandora-connector-houdini
+  - islandora-connector-derivative
 
 alpaca_karaf_dir: /opt/karaf
 alpaca_karaf_etc_dir: "{{ alpaca_karaf_dir }}/etc"
+alpaca_karaf_deploy_dir: "{{ alpaca_karaf_dir }}/deploy"
 alpaca_karaf_user: karaf
 alpaca_local_mvn_path: /opt/maven/repo
 
 alpaca_settings:
-  - pid: ca.islandora.alpaca.connector.broadcast
+  - pid: ca.islandora.alpaca.http.client
     settings:
-      input.stream: activemq:queue:islandora-connector-broadcast
+      token.value: islandora
   - pid: ca.islandora.alpaca.indexing.triplestore
     settings:
       error.maxRedeliveries: 10
-      input.stream: activemq:queue:islandora-indexing-triplestore
+      index.stream: activemq:queue:islandora-indexing-triplestore-index
+      delete.stream: activemq:queue:islandora-indexing-triplestore-delete
       triplestore.baseUrl: http://localhost:8080/bigdata/namespace/islandora/sparql
+  - pid: ca.islandora.alpaca.indexing.fcrepo
+    settings:
+      error.maxRedeliveries: 5
+      node.stream: activemq:queue:islandora-indexing-fcrepo-content
+      node.delete.stream: activemq:queue:islandora-indexing-fcrepo-delete
+      media.stream: activemq:queue:islandora-indexing-fcrepo-media
+      file.stream: activemq:queue:islandora-indexing-fcrepo-file
+      file.delete.stream: activemq:queue:islandora-indexing-fcrepo-file-delete
+      milliner.baseUrl: http://localhost:8000/milliner/
+      gemini.baseUrl: http://localhost:8000/gemini/
+
+alpaca_blueprint_settings:
+  - pid: ca.islandora.alpaca.connector.houdini
+    in_stream: activemq:queue:islandora-connector-houdini
+    derivative_service_url: http://localhost:8000/houdini/convert
+    error_max_redeliveries: 5
+    camel_context_id: IslandoraConnectorHoudini
+  - pid: ca.islandora.alpaca.connector.homarus
+    in_stream: activemq:queue:islandora-connector-homarus
+    derivative_service_url: http://localhost:8000/homarus/convert
+    error_max_redeliveries: 5
+    camel_context_id: IslandoraConnectorHomarus

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,3 +5,9 @@
     src: alpaca.cfg.j2
     dest: "{{ alpaca_karaf_etc_dir }}/{{ item.pid }}.cfg"
   with_items: "{{ alpaca_settings }}"
+
+- name: Template blueprint files
+  template:
+    src: blueprint.xml.j2
+    dest: "{{ alpaca_karaf_deploy_dir }}/{{ item.pid }}.blueprint.xml"
+  with_items: "{{ alpaca_blueprint_settings }}"

--- a/templates/blueprint.xml.j2
+++ b/templates/blueprint.xml.j2
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- managed by ansible -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+       xsi:schemaLocation="
+       http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+       http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+       http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+  <cm:property-placeholder id="properties" persistent-id="{{ item.pid }}" update-strategy="reload" >
+    <cm:default-properties>
+      <cm:property name="error.maxRedeliveries" value="{{ item.error_max_redeliveries }}"/>
+      <cm:property name="in.stream" value="{{ item.in_stream }}"/>
+      <cm:property name="derivative.service.url" value="{{ item.derivative_service_url }}"/>
+    </cm:default-properties>
+  </cm:property-placeholder>
+
+  <reference id="broker" interface="org.apache.camel.Component" filter="(osgi.jndi.service.name=fcrepo/Broker)"/>
+
+  <bean id="http" class="org.apache.camel.component.http4.HttpComponent"/>
+  <bean id="https" class="org.apache.camel.component.http4.HttpComponent"/>
+
+  <camelContext id="{{ item.camel_context_id }}" xmlns="http://camel.apache.org/schema/blueprint">
+    <package>ca.islandora.alpaca.connector.derivative</package>
+  </camelContext>
+
+</blueprint>


### PR DESCRIPTION
This PR updates the role to template out blueprint xml files.  Each file is deployed in karaf to start a small listener to generate derivatives.

You can test this PR with https://github.com/Islandora-Devops/claw-playbook/pull/89