### PR TITLE
External content, fedora 5.0, and triplestore indexing fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ alpaca_karaf_etc_dir: "{{ alpaca_karaf_dir }}/etc"
 alpaca_karaf_deploy_dir: "{{ alpaca_karaf_dir }}/deploy"
 alpaca_karaf_user: karaf
 alpaca_local_mvn_path: /opt/maven/repo
-  
+
 alpaca_settings:
   - pid: ca.islandora.alpaca.http.client
     settings:
@@ -50,7 +50,7 @@ alpaca_settings:
       file.delete.stream: activemq:queue:islandora-indexing-fcrepo-file-delete
       milliner.baseUrl: http://localhost:8000/milliner/
       gemini.baseUrl: http://localhost:8000/gemini/
-      
+
 alpaca_blueprint_settings:
   - pid: ca.islandora.alpaca.connector.houdini
     in_stream: activemq:queue:islandora-connector-houdini

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,12 +7,13 @@ alpaca_clone_directory: /opt/alpaca
 alpaca_karaf_repos:
   - mvn:org.apache.camel.karaf/apache-camel/2.20.4/xml/features
   - mvn:org.apache.activemq/activemq-karaf/5.15.0/xml/features
-  - file:{{ alpaca_clone_directory }}/karaf/build/resources/main/features.xml
- #- mvn:ca.islandora.alpaca/islandora-karaf/LATEST/xml/features
+  - mvn:ca.islandora.alpaca/islandora-karaf/LATEST/xml/features
 
 alpaca_features:
-  - camel
-  - activemq-camel
+  - fcrepo-service-activemq
+  - fcrepo-camel
+  - fcrepo-service-camel
+  - fcrepo-indexing-triplestore
   - islandora-http-client
   - islandora-indexing-triplestore
   - islandora-indexing-fcrepo
@@ -23,11 +24,16 @@ alpaca_karaf_etc_dir: "{{ alpaca_karaf_dir }}/etc"
 alpaca_karaf_deploy_dir: "{{ alpaca_karaf_dir }}/deploy"
 alpaca_karaf_user: karaf
 alpaca_local_mvn_path: /opt/maven/repo
-
+  
 alpaca_settings:
   - pid: ca.islandora.alpaca.http.client
     settings:
       token.value: islandora
+  - pid: org.fcrepo.camel.indexing.triplestore
+    settings:
+      input.stream: activemq:topic:fedora
+      triplestore.reindex.stream: activemq:queue:triplestore.reindex
+      triplestore.baseUrl: http://localhost:8080/bigdata/namespace/islandora/sparql
   - pid: ca.islandora.alpaca.indexing.triplestore
     settings:
       error.maxRedeliveries: 10
@@ -44,7 +50,7 @@ alpaca_settings:
       file.delete.stream: activemq:queue:islandora-indexing-fcrepo-file-delete
       milliner.baseUrl: http://localhost:8000/milliner/
       gemini.baseUrl: http://localhost:8000/gemini/
-
+      
 alpaca_blueprint_settings:
   - pid: ca.islandora.alpaca.connector.houdini
     in_stream: activemq:queue:islandora-connector-houdini

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,18 @@
 ---
 
 alpaca_from_source: no
-
 alpaca_version: master
 alpaca_clone_directory: /opt/alpaca
 
 alpaca_karaf_repos:
-  - mvn:ca.islandora.alpaca/islandora-karaf/LATEST/xml/features
+  - mvn:org.apache.camel.karaf/apache-camel/2.20.4/xml/features
+  - mvn:org.apache.activemq/activemq-karaf/5.15.0/xml/features
+  - file:{{ alpaca_clone_directory }}/karaf/build/resources/main/features.xml
+ #- mvn:ca.islandora.alpaca/islandora-karaf/LATEST/xml/features
 
 alpaca_features:
+  - camel
+  - activemq-camel
   - islandora-http-client
   - islandora-indexing-triplestore
   - islandora-indexing-fcrepo

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ alpaca_clone_directory: /opt/alpaca
 alpaca_karaf_repos:
   - mvn:org.apache.camel.karaf/apache-camel/2.20.4/xml/features
   - mvn:org.apache.activemq/activemq-karaf/5.15.0/xml/features
-  - mvn:ca.islandora.alpaca/islandora-karaf/LATEST/xml/features
+  - mvn:ca.islandora.alpaca/islandora-karaf/0.8.0/xml/features
 
 alpaca_features:
   - fcrepo-service-activemq

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -1,17 +1,10 @@
 ---
 
-- name: Add Alpaca Repos (source)
-  karaf_repo:
-    state: present
-    name: file:{{ alpaca_clone_directory }}/karaf/build/resources/main/features.xml
-  when: alpaca_from_source
-
 - name: Add Alpaca Repos (package)
   karaf_repo:
     state: present
     name: "{{ item }}"
   with_items: "{{ alpaca_karaf_repos }}"
-  when: not alpaca_from_source
 
 - name: Add Alpaca Features
   karaf_feature:

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Add Alpaca Repos (package)
+- name: Add Alpaca Repos
   karaf_repo:
     state: present
     name: "{{ item }}"


### PR DESCRIPTION
Part of https://github.com/Islandora-CLAW/CLAW/issues/1079

Deploys alpaca with new features repos to handle the new fcrepo5 client, fcrepo-camel-toolbox, camel, and activemq.

Test with https://github.com/Islandora-Devops/claw-playbook/pull/100