### PR TITLE
Made fits address overrideable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,7 @@ alpaca_milliner_base_url: http://localhost:8000/milliner
 alpaca_gemini_base_url: http://localhost:8000/gemini
 alpaca_houdini_base_url: http://localhost:8000/houdini
 alpaca_homarus_base_url: http://localhost:8000/homarus
+alpaca_fits_base_url: http://localhost:8000/crayfits
 
 alpaca_settings:
   - pid: ca.islandora.alpaca.http.client
@@ -76,6 +77,6 @@ alpaca_blueprint_settings:
     camel_context_id: IslandoraConnectorHomarus
   - pid: ca.islandora.alpaca.connector.fits
     in_stream: activemq:queue:islandora-connector-fits
-    derivative_service_url: http://localhost:8000/crayfits/
+    derivative_service_url: "{{ alpaca_fits_base_url }}"
     error_max_redeliveries: 5
     camel_context_id: IslandoraConnectorFits


### PR DESCRIPTION
# What does this Pull Request do?

A tiny change in config that will allow users to override the web address for the FITS microservice

# What's new?
 Switched out one hardcoded value for a variable.

# How should this be tested?

Spinning up a new box should create a ca.islandora.alpaca.connector.fits file under /opt/karaf/deploy
The derivative.service.url should be http://localhost:8000/crayfits, unless you changed alpaca_fits_base_url in your startup config.

# Interested parties 
@Islandora-Devops/committers
