### PR TITLE
Making hypercube_url overrideable. Using variable for syn token.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,11 +32,12 @@ alpaca_gemini_base_url: http://localhost:8000/gemini
 alpaca_houdini_base_url: http://localhost:8000/houdini
 alpaca_homarus_base_url: http://localhost:8000/homarus
 alpaca_fits_base_url: http://localhost:8000/crayfits
+alpaca_hypercube_base_url: http://localhost:8000/hypercube
 
 alpaca_settings:
   - pid: ca.islandora.alpaca.http.client
     settings:
-      token.value: islandora
+      token.value: "{{ islandora_syn_token }}"
   - pid: org.fcrepo.camel.indexing.triplestore
     settings:
       input.stream: activemq:topic:fedora
@@ -62,7 +63,7 @@ alpaca_settings:
 alpaca_blueprint_settings:
   - pid: ca.islandora.alpaca.connector.ocr
     in_stream: activemq:queue:islandora-connector-ocr
-    derivative_service_url: http://localhost:8000/hypercube
+    derivative_service_url: "{{ alpaca_hypercube_base_url }}"
     error_max_redeliveries: 5
     camel_context_id: IslandoraConnectorOCR
   - pid: ca.islandora.alpaca.connector.houdini

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,8 @@ alpaca_karaf_user: karaf
 alpaca_local_mvn_path: /opt/maven/repo
 
 triplestore_namespace: islandora
+islandora_syn_token: islandora
+
 alpaca_triplestore_base_url: http://localhost:8080/bigdata
 alpaca_milliner_base_url: http://localhost:8000/milliner
 alpaca_gemini_base_url: http://localhost:8000/gemini


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1409

# What does this Pull Request do?

Makes a variable for hypercube's url and uses it.  Also uses the pre-existing `islandora_syn_token` for configuring alpaca's http client.  With this, we can eliminate having to update `karaf.yml` in our inventory for provisioning remote servers.

# How should this be tested?

Pull in this PR, delete `roles/external`, then `vagrant up`.  Everything should provision normally.  Try creating an OCR derivative and see if it still works.  

# Interested parties
@Islandora-Devops/committers
