### PR TITLE
Pull latest karaf version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ alpaca_clone_directory: /opt/alpaca
 alpaca_karaf_repos:
   - mvn:org.apache.camel.karaf/apache-camel/2.20.4/xml/features
   - mvn:org.apache.activemq/activemq-karaf/5.15.0/xml/features
-  - mvn:ca.islandora.alpaca/islandora-karaf/1.0.1/xml/features
+  - mvn:ca.islandora.alpaca/islandora-karaf/LATEST/xml/features
 
 alpaca_features:
   - fcrepo-service-activemq


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

Instead of updating this role for each version, this will pull in the latest version from maven.

Instead a release of the islandora-playbook should pin the version by overriding this variable.

# How should this be tested?

This should automatically pull the latest version (which is currently 1.0.3). 

Test https://github.com/Islandora-Devops/islandora-playbook/pull/176 instead which does the same thing.

This PR only affects people using this role separate from the islandora-playbook framework.

# Interested parties
@Islandora-Devops/committers
