### PR TITLE
updating defaults to point at broker

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ alpaca_settings:
       token.value: islandora
   - pid: org.fcrepo.camel.indexing.triplestore
     settings:
-      input.stream: activemq:topic:fedora
+      input.stream: broker:topic:fedora
       triplestore.reindex.stream: broker:queue:triplestore.reindex
       triplestore.baseUrl: "{{ alpaca_triplestore_base_url }}/namespace/{{ triplestore_namespace }}/sparql"
   - pid: ca.islandora.alpaca.indexing.triplestore

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,43 +40,43 @@ alpaca_settings:
   - pid: org.fcrepo.camel.indexing.triplestore
     settings:
       input.stream: activemq:topic:fedora
-      triplestore.reindex.stream: activemq:queue:triplestore.reindex
+      triplestore.reindex.stream: broker:queue:triplestore.reindex
       triplestore.baseUrl: "{{ alpaca_triplestore_base_url }}/namespace/{{ triplestore_namespace }}/sparql"
   - pid: ca.islandora.alpaca.indexing.triplestore
     settings:
       error.maxRedeliveries: 10
-      index.stream: activemq:queue:islandora-indexing-triplestore-index
-      delete.stream: activemq:queue:islandora-indexing-triplestore-delete
+      index.stream: broker:queue:islandora-indexing-triplestore-index
+      delete.stream: broker:queue:islandora-indexing-triplestore-delete
       triplestore.baseUrl: "{{ alpaca_triplestore_base_url }}/namespace/{{ triplestore_namespace }}/sparql"
   - pid: ca.islandora.alpaca.indexing.fcrepo
     settings:
       error.maxRedeliveries: 5
-      node.stream: activemq:queue:islandora-indexing-fcrepo-content
-      node.delete.stream: activemq:queue:islandora-indexing-fcrepo-delete
-      media.stream: activemq:queue:islandora-indexing-fcrepo-media
-      file.stream: activemq:queue:islandora-indexing-fcrepo-file
-      file.delete.stream: activemq:queue:islandora-indexing-fcrepo-file-delete
+      node.stream: broker:queue:islandora-indexing-fcrepo-content
+      node.delete.stream: broker:queue:islandora-indexing-fcrepo-delete
+      media.stream: broker:queue:islandora-indexing-fcrepo-media
+      file.stream: broker:queue:islandora-indexing-fcrepo-file
+      file.delete.stream: broker:queue:islandora-indexing-fcrepo-file-delete
       milliner.baseUrl: "{{ alpaca_milliner_base_url }}"
       gemini.baseUrl: "{{ alpaca_gemini_base_url }}"
 
 alpaca_blueprint_settings:
   - pid: ca.islandora.alpaca.connector.ocr
-    in_stream: activemq:queue:islandora-connector-ocr
+    in_stream: broker:queue:islandora-connector-ocr
     derivative_service_url: http://localhost:8000/hypercube
     error_max_redeliveries: 5
     camel_context_id: IslandoraConnectorOCR
   - pid: ca.islandora.alpaca.connector.houdini
-    in_stream: activemq:queue:islandora-connector-houdini
+    in_stream: broker:queue:islandora-connector-houdini
     derivative_service_url: "{{ alpaca_houdini_base_url }}/convert"
     error_max_redeliveries: 5
     camel_context_id: IslandoraConnectorHoudini
   - pid: ca.islandora.alpaca.connector.homarus
-    in_stream: activemq:queue:islandora-connector-homarus
+    in_stream: broker:queue:islandora-connector-homarus
     derivative_service_url: "{{ alpaca_homarus_base_url }}/convert"
     error_max_redeliveries: 5
     camel_context_id: IslandoraConnectorHomarus
   - pid: ca.islandora.alpaca.connector.fits
-    in_stream: activemq:queue:islandora-connector-fits
+    in_stream: broker:queue:islandora-connector-fits
     derivative_service_url: "{{ alpaca_fits_base_url }}"
     error_max_redeliveries: 5
     camel_context_id: IslandoraConnectorFits


### PR DESCRIPTION
**GitHub Issue**:
N/A
* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)
https://islandora.slack.com/archives/CM5PPAV28/p1594817434364600

# What does this Pull Request do?

Updates the defaults entries used for queue / topics to use the broker specified with 

`./templates/blueprint.xml.j2:  <reference id="broker" interface="org.apache.camel.Component" filter="(osgi.jndi.service.name=fcrepo/Broker)"/>`

# What's new?
Updates the defaults entries used for queue / topics so that it will actually use fcrepo broker. 

If you update the broker information in /opt/karaf/etc/org.fcrepo.camel.service.activemq.cfg it will now work with whatever you specify. Previously it would only use the "FailoverTransport" with `activemq:`

* Changed  `activemq:` in defaults to be `broker:`

# How should this be tested?

If you were to spin up a box without this PR and attempt to use a remote broker with /opt/karaf/etc/org.fcrepo.camel.service.activemq.cfg it will not work. 

If you spin up a box with this PR and update /opt/karaf/etc/org.fcrepo.camel.service.activemq.cfg  to use a remote broker it will now work. 

You will need to have a seperate box running that you can use as a remote broker. You shouldn't use the localhost broker for testing since it will always work anyway as the "FailoverTransport"

# Additional Notes:
Worked this out with the help of @dannylamb 

# Interested parties
@dannylamb 
